### PR TITLE
Updates to our queries to line up with operator meter changes

### DIFF
--- a/roles/setup/files/hccm_openshift_usage_report_generation_query.yaml
+++ b/roles/setup/files/hccm_openshift_usage_report_generation_query.yaml
@@ -71,6 +71,8 @@ spec:
       FROM {| generationQueryViewName "pod-cpu-usage-raw" |}
       WHERE "timestamp" >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
         AND "timestamp" < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
+        AND dt >= '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prometheusMetricPartitionFormat |}'
+        AND dt <= '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prometheusMetricPartitionFormat |}'
       GROUP BY namespace, pod, node, date_trunc('hour', "timestamp")
     ),
     cte_hourly_pod_cpu_requests AS (
@@ -82,6 +84,8 @@ spec:
       FROM {| generationQueryViewName "pod-cpu-request-raw" |}
       WHERE "timestamp" >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
         AND "timestamp" < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
+        AND dt >= '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prometheusMetricPartitionFormat |}'
+        AND dt <= '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prometheusMetricPartitionFormat |}'
       GROUP BY namespace, pod, node, date_trunc('hour', "timestamp")
     ),
     cte_hourly_pod_cpu_limits AS (
@@ -93,6 +97,8 @@ spec:
       FROM {| generationQueryViewName "pod-cpu-limit-raw" |}
       WHERE "timestamp" >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
         AND "timestamp" < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
+        AND dt >= '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prometheusMetricPartitionFormat |}'
+        AND dt <= '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prometheusMetricPartitionFormat |}'
       GROUP BY namespace, pod, node, date_trunc('hour', "timestamp")
     ),
     cte_hourly_pod_memory_usage AS (
@@ -104,6 +110,8 @@ spec:
       FROM {| generationQueryViewName "pod-memory-usage-raw" |}
       WHERE "timestamp" >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
         AND "timestamp" < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
+        AND dt >= '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prometheusMetricPartitionFormat |}'
+        AND dt <= '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prometheusMetricPartitionFormat |}'
       GROUP BY namespace, pod, node, date_trunc('hour', "timestamp")
     ),
     cte_hourly_pod_memory_requests AS (
@@ -115,6 +123,8 @@ spec:
       FROM {| generationQueryViewName "pod-memory-request-raw" |}
       WHERE "timestamp" >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
         AND "timestamp" < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
+        AND dt >= '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prometheusMetricPartitionFormat |}'
+        AND dt <= '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prometheusMetricPartitionFormat |}'
       GROUP BY namespace, pod, node, date_trunc('hour', "timestamp")
     ),
     cte_hourly_pod_memory_limits AS (
@@ -126,6 +136,8 @@ spec:
       FROM {| generationQueryViewName "pod-memory-limit-raw" |}
       WHERE "timestamp" >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
         AND "timestamp" < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
+        AND dt >= '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prometheusMetricPartitionFormat |}'
+        AND dt <= '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prometheusMetricPartitionFormat |}'
       GROUP BY namespace, pod, node, date_trunc('hour', "timestamp")
     ),
     cte_hourly_node_capacity_cpu AS (
@@ -133,9 +145,11 @@ spec:
         date_trunc('hour', "timestamp") as interval_start,
         max(node_capacity_cpu_cores) as node_capacity_cpu_cores,
         sum(node_capacity_cpu_core_seconds) as node_capacity_cpu_core_seconds
-      FROM {| generationQueryViewName "node-cpu-capacity" |}
+      FROM {| generationQueryViewName "node-cpu-capacity-raw" |}
       WHERE "timestamp" >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
         AND "timestamp" < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
+        AND dt >= '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prometheusMetricPartitionFormat |}'
+        AND dt <= '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prometheusMetricPartitionFormat |}'
       GROUP BY node, date_trunc('hour', "timestamp")
     ),
     cte_hourly_node_capacity_memory AS (
@@ -143,9 +157,11 @@ spec:
         date_trunc('hour', "timestamp") as interval_start,
         max(node_capacity_memory_bytes) as node_capacity_memory_bytes,
         sum(node_capacity_memory_byte_seconds) as node_capacity_memory_byte_seconds
-      FROM {| generationQueryViewName "node-memory-capacity" |}
+      FROM {| generationQueryViewName "node-memory-capacity-raw" |}
       WHERE "timestamp" >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
         AND "timestamp" < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
+        AND dt >= '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prometheusMetricPartitionFormat |}'
+        AND dt <= '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prometheusMetricPartitionFormat |}'
       GROUP BY node, date_trunc('hour', "timestamp")
     ),
     cte_hourly_pod_labels AS (
@@ -153,9 +169,11 @@ spec:
         pod,
         date_trunc('hour', "timestamp") as interval_start,
         array_join(map_values(transform_values(map_filter(map_union(labels), (k, v) -> k LIKE 'label_%'), (k, v) -> concat(k, ':', v))), '|') as pod_labels
-      FROM {| generationQueryViewName "pod-labels" |}
+      FROM {| generationQueryViewName "pod-labels-raw" |}
       WHERE "timestamp" >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
         AND "timestamp" < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
+        AND dt >= '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prometheusMetricPartitionFormat |}'
+        AND dt <= '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prometheusMetricPartitionFormat |}'
       GROUP BY namespace, pod, date_trunc('hour', "timestamp")
     )
     SELECT
@@ -220,8 +238,8 @@ spec:
     - pod-memory-usage-raw
     - pod-memory-request-raw
     - pod-memory-limit-raw
-    - node-cpu-capacity
-    - node-memory-capacity
-    - pod-labels
+    - node-cpu-capacity-raw
+    - node-memory-capacity-raw
+    - pod-labels-raw
   view:
     disabled: true

--- a/roles/setup/files/pod-labels_report_generation_query.yaml
+++ b/roles/setup/files/pod-labels_report_generation_query.yaml
@@ -2,7 +2,7 @@
 apiVersion: metering.openshift.io/v1alpha1
 kind: ReportGenerationQuery
 metadata:
-  name: "pod-labels"
+  name: "pod-labels-raw"
 spec:
   reportDataSources:
     - "kube-pod-labels"
@@ -18,9 +18,13 @@ spec:
     - name: timestamp
       type: timestamp
       unit: date
+    - name: dt
+      type: string
   query: |
     SELECT labels['pod'] as pod,
         labels['namespace'] as namespace,
         labels,
-        "timestamp"
+        "timestamp",
+        dt
     FROM {| dataSourceTableName "kube-pod-labels" |}
+    WHERE element_at(labels, 'pod') IS NOT NULL

--- a/roles/setup/files/pod-limit-cpu-cores_report_generation_query.yaml
+++ b/roles/setup/files/pod-limit-cpu-cores_report_generation_query.yaml
@@ -33,6 +33,8 @@ spec:
     - name: timestamp
       type: timestamp
       unit: date
+    - name: dt
+      type: string
   query: |
       SELECT labels['pod'] as pod,
           labels['namespace'] as namespace,
@@ -41,6 +43,7 @@ spec:
           amount as pod_limit_cpu_cores,
           timeprecision,
           amount * timeprecision as pod_limit_cpu_core_seconds,
-          "timestamp"
+          "timestamp",
+          dt
       FROM {| dataSourceTableName "pod-limit-cpu-cores" |}
       WHERE element_at(labels, 'node') IS NOT NULL

--- a/roles/setup/files/pod-limit-memory-bytes_report_generation_query.yaml
+++ b/roles/setup/files/pod-limit-memory-bytes_report_generation_query.yaml
@@ -33,6 +33,8 @@ spec:
     - name: timestamp
       type: timestamp
       unit: date
+    - name: dt
+      type: string
   query: |
       SELECT labels['pod'] as pod,
           labels['namespace'] as namespace,
@@ -41,6 +43,7 @@ spec:
           amount as pod_limit_memory_bytes,
           timeprecision,
           amount * timeprecision as pod_limit_memory_byte_seconds,
-          "timestamp"
+          "timestamp",
+          dt
       FROM {| dataSourceTableName "pod-limit-memory-bytes" |}
       WHERE element_at(labels, 'node') IS NOT NULL


### PR DESCRIPTION
## Summary
This uses `-raw` queries for all of our data sources. Recently in the operator meter the node capacity queries were renamed to raw, which was what broke our reporting. The rest of the changes are to line up with the use of the `dt` column in queries -- which has to do with data partitions. 