### PR TITLE
Adding storage reporting operator metering object yamls

### DIFF
--- a/roles/setup/files/hccm_openshift_persistentvolumeclaim_lookback_report_generation_query.yaml
+++ b/roles/setup/files/hccm_openshift_persistentvolumeclaim_lookback_report_generation_query.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: metering.openshift.io/v1alpha1
+kind: ReportGenerationQuery
+metadata:
+  name: hccm-openshift-persistentvolumeclaim-lookback
+spec:
+  view:
+    disabled: true
+  columns:
+    - name: report_period_start
+      type: timestamp
+      unit: date
+    - name: report_period_end
+      type: timestamp
+      unit: date
+    - name: interval_start
+      type: timestamp
+      unit: date
+    - name: interval_end
+      type: timestamp
+      unit: date
+    - name: namespace
+      type: string
+      unit: kubernetes_namespace
+    - name: persistentvolumeclaim
+      type: string
+      unit: kubernetes_persistentvolumeclaim
+    - name: persistentvolume
+      type: string
+      unit: kubernetes_persistentvolume
+    - name: storageclass
+      type: string
+      unit: kubernetes_storageclass
+    - name: persistentvolumeclaim_capacity_bytes
+      type: double
+      unit: bytes
+    - name: persistentvolumeclaim_capacity_byte_seconds
+      type: double
+      unit: byte_seconds
+    - name: volume_request_storage_byte_seconds
+      type: double
+      unit: byte_seconds
+    - name: persistentvolumeclaim_usage_byte_seconds
+      type: double
+      unit: byte_seconds
+  inputs:
+    - name: ReportingStart
+    - name: AggregatedReportName
+      required: true
+  query: |
+    SELECT report_period_start,
+      report_period_end,
+      interval_start,
+      interval_end,
+      namespace,
+      persistentvolumeclaim,
+      persistentvolume,
+      storageclass,
+      persistentvolumeclaim_capacity_bytes,
+      persistentvolumeclaim_capacity_byte_seconds,
+      volume_request_storage_byte_seconds,
+      persistentvolumeclaim_usage_byte_seconds
+    FROM {| .Report.Inputs.AggregatedReportName | reportTableName |}
+    WHERE {| .Report.Inputs.AggregatedReportName | reportTableName |}.interval_start >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}' - interval '10' day

--- a/roles/setup/files/hccm_openshift_persistentvolumeclaim_lookback_report_generation_query.yaml
+++ b/roles/setup/files/hccm_openshift_persistentvolumeclaim_lookback_report_generation_query.yaml
@@ -22,6 +22,9 @@ spec:
     - name: namespace
       type: string
       unit: kubernetes_namespace
+    - name: pod
+      type: string
+      unit: kubernetes_pod
     - name: persistentvolumeclaim
       type: string
       unit: kubernetes_persistentvolumeclaim
@@ -43,6 +46,10 @@ spec:
     - name: persistentvolumeclaim_usage_byte_seconds
       type: double
       unit: byte_seconds
+    - name: persistentvolume_labels
+      type: string
+    - name: persistentvolumeclaim_labels
+      type: string
   inputs:
     - name: ReportingStart
     - name: AggregatedReportName
@@ -53,12 +60,15 @@ spec:
       interval_start,
       interval_end,
       namespace,
+      pod,
       persistentvolumeclaim,
       persistentvolume,
       storageclass,
       persistentvolumeclaim_capacity_bytes,
       persistentvolumeclaim_capacity_byte_seconds,
       volume_request_storage_byte_seconds,
-      persistentvolumeclaim_usage_byte_seconds
+      persistentvolumeclaim_usage_byte_seconds,
+      persistentvolume_labels,
+      persistentvolumeclaim_labels
     FROM {| .Report.Inputs.AggregatedReportName | reportTableName |}
     WHERE {| .Report.Inputs.AggregatedReportName | reportTableName |}.interval_start >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}' - interval '10' day

--- a/roles/setup/files/hccm_openshift_persistentvolumeclaim_lookback_scheduled_report.yaml
+++ b/roles/setup/files/hccm_openshift_persistentvolumeclaim_lookback_scheduled_report.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: metering.openshift.io/v1alpha1
+kind: Report
+metadata:
+  name: hccm-openshift-persistentvolumeclaim-lookback
+spec:
+  generationQuery: "hccm-openshift-persistentvolumeclaim-lookback"
+  inputs:
+    - name: "AggregatedReportName"
+      value: "hccm-openshift-persistentvolumeclaim"
+  gracePeriod: "10m"  # wait for sub-query to finish
+  schedule:
+    period: "hourly"
+  overwriteExistingData: true

--- a/roles/setup/files/hccm_openshift_persistentvolumeclaim_report_generation_query.yaml
+++ b/roles/setup/files/hccm_openshift_persistentvolumeclaim_report_generation_query.yaml
@@ -1,0 +1,114 @@
+---
+apiVersion: metering.openshift.io/v1alpha1
+kind: ReportGenerationQuery
+metadata:
+  name: hccm-openshift-persistentvolumeclaim
+spec:
+  columns:
+    - name: report_period_start
+      type: timestamp
+      unit: date
+    - name: report_period_end
+      type: timestamp
+      unit: date
+    - name: interval_start
+      type: timestamp
+      unit: date
+    - name: interval_end
+      type: timestamp
+      unit: date
+    - name: namespace
+      type: string
+      unit: kubernetes_namespace
+    - name: persistentvolumeclaim
+      type: string
+      unit: kubernetes_persistentvolumeclaim
+    - name: persistentvolume
+      type: string
+      unit: kubernetes_persistentvolume
+    - name: storageclass
+      type: string
+      unit: kubernetes_storageclass
+    - name: persistentvolumeclaim_capacity_bytes
+      type: double
+      unit: bytes
+    - name: persistentvolumeclaim_capacity_byte_seconds
+      type: double
+      unit: byte_seconds
+    - name: volume_request_storage_byte_seconds
+      type: double
+      unit: byte_seconds
+    - name: persistentvolumeclaim_usage_byte_seconds
+      type: double
+      unit: byte_seconds
+  inputs:
+    - name: ReportingStart
+    - name: ReportingEnd
+  query: |
+    WITH cte_hourly_persistentvolumeclaim_capacity AS (
+      SELECT date_trunc('hour', "timestamp") as interval_start,
+        namespace,
+        persistentvolumeclaim,
+        max(persistentvolumeclaim_capacity_bytes) as persistentvolumeclaim_capacity_bytes,
+        sum(persistentvolumeclaim_capacity_byte_seconds) as persistentvolumeclaim_capacity_byte_seconds
+      FROM {| generationQueryViewName "persistentvolumeclaim-capacity-raw" |}
+      WHERE "timestamp" >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
+        AND "timestamp" < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
+        AND dt >= '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prometheusMetricPartitionFormat |}'
+        AND dt <= '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prometheusMetricPartitionFormat |}'
+      GROUP BY namespace, persistentvolumeclaim, date_trunc('hour', "timestamp")
+    ),
+    cte_hourly_persistentvolumeclaim_requests AS (
+      SELECT date_trunc('hour', "timestamp") as interval_start,
+        namespace,
+        persistentvolumeclaim,
+        max(persistentvolume) as persistentvolume,
+        max(storageclass) as storageclass,
+        sum(volume_request_storage_byte_seconds) as volume_request_storage_byte_seconds
+      FROM {| generationQueryViewName "persistentvolumeclaim-request-raw" |}
+      WHERE "timestamp" >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
+        AND "timestamp" < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
+        AND dt >= '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prometheusMetricPartitionFormat |}'
+        AND dt <= '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prometheusMetricPartitionFormat |}'
+      GROUP BY namespace, persistentvolumeclaim, date_trunc('hour', "timestamp")
+    ),
+    cte_hourly_persistentvolumeclaim_usage AS (
+      SELECT date_trunc('hour', "timestamp") as interval_start,
+        namespace,
+        persistentvolumeclaim,
+        sum(persistentvolumeclaim_usage_byte_seconds) as persistentvolumeclaim_usage_byte_seconds
+      FROM {| generationQueryViewName "persistentvolumeclaim-usage-raw" |}
+      WHERE "timestamp" >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
+        AND "timestamp" < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
+        AND dt >= '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prometheusMetricPartitionFormat |}'
+        AND dt <= '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prometheusMetricPartitionFormat |}'
+      GROUP BY namespace, persistentvolumeclaim, date_trunc('hour', "timestamp")
+    )
+    SELECT
+      date_trunc('month', timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart| prestoTimestamp |}') AS report_period_start,
+      date_trunc('month', timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}')  + interval '1' month - interval '1' second AS report_period_end,
+      PVCU.interval_start,
+      PVCU.interval_start + interval '59' minute + interval '59' second as interval_end,
+      PVCU.namespace,
+      PVCU.persistentvolumeclaim,
+      PVCR.persistentvolume,
+      PVCR.storageclass,
+      PVCC.persistentvolumeclaim_capacity_bytes,
+      PVCC.persistentvolumeclaim_capacity_byte_seconds,
+      PVCR.volume_request_storage_byte_seconds,
+      PVCU.persistentvolumeclaim_usage_byte_seconds
+    FROM cte_hourly_persistentvolumeclaim_usage AS PVCU
+    JOIN cte_hourly_persistentvolumeclaim_requests AS PVCR
+        ON PVCU.namespace = PVCR.namespace
+          AND PVCU.persistentvolumeclaim = PVCR.persistentvolumeclaim
+          AND PVCU.interval_start = PVCR.interval_start
+    JOIN cte_hourly_persistentvolumeclaim_capacity AS PVCC
+        ON PVCU.namespace = PVCC.namespace
+          AND PVCU.persistentvolumeclaim = PVCC.persistentvolumeclaim
+          AND PVCU.interval_start = PVCC.interval_start
+  reportQueries:
+    - persistentvolumeclaim-capacity-raw
+    - persistentvolumeclaim-request-raw
+    - persistentvolumeclaim-usage-raw
+  view:
+    disabled: true

--- a/roles/setup/files/hccm_openshift_persistentvolumeclaim_report_generation_query.yaml
+++ b/roles/setup/files/hccm_openshift_persistentvolumeclaim_report_generation_query.yaml
@@ -20,6 +20,9 @@ spec:
     - name: namespace
       type: string
       unit: kubernetes_namespace
+    - name: pod
+      type: string
+      unit: kubernetes_pod
     - name: persistentvolumeclaim
       type: string
       unit: kubernetes_persistentvolumeclaim
@@ -41,6 +44,10 @@ spec:
     - name: persistentvolumeclaim_usage_byte_seconds
       type: double
       unit: byte_seconds
+    - name: persistentvolume_labels
+      type: string
+    - name: persistentvolumeclaim_labels
+      type: string
   inputs:
     - name: ReportingStart
     - name: ReportingEnd
@@ -83,6 +90,42 @@ spec:
         AND dt >= '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prometheusMetricPartitionFormat |}'
         AND dt <= '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prometheusMetricPartitionFormat |}'
       GROUP BY namespace, persistentvolumeclaim, date_trunc('hour', "timestamp")
+    ),
+    cte_hourly_pvc_labels AS (
+      SELECT date_trunc('hour', "timestamp") as interval_start,
+        namespace,
+        persistentvolumeclaim,
+        array_join(map_values(transform_values(map_filter(map_union(labels), (k, v) -> k LIKE 'label_%'), (k, v) -> concat(k, ':', v))), '|') as persistentvolumeclaim_labels
+      FROM {| generationQueryViewName "persistentvolumeclaim-labels-raw" |}
+      WHERE "timestamp" >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
+        AND "timestamp" < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
+        AND dt >= '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prometheusMetricPartitionFormat |}'
+        AND dt <= '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prometheusMetricPartitionFormat |}'
+      GROUP BY namespace, persistentvolumeclaim, date_trunc('hour', "timestamp")
+    ),
+    cte_hourly_pv_labels AS (
+      SELECT date_trunc('hour', "timestamp") as interval_start,
+        namespace,
+        persistentvolume,
+        array_join(map_values(transform_values(map_filter(map_union(labels), (k, v) -> k LIKE 'label_%'), (k, v) -> concat(k, ':', v))), '|') as persistentvolume_labels
+      FROM {| generationQueryViewName "persistentvolume-labels-raw" |}
+      WHERE "timestamp" >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
+        AND "timestamp" < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
+        AND dt >= '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prometheusMetricPartitionFormat |}'
+        AND dt <= '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prometheusMetricPartitionFormat |}'
+      GROUP BY namespace, persistentvolume, date_trunc('hour', "timestamp")
+    ),
+    cte_pod_pvc_info AS (
+      SELECT date_trunc('hour', "timestamp") as interval_start,
+        namespace,
+        pod,
+        persistentvolumeclaim
+      FROM {| generationQueryViewName "pod-persistentvolumeclaim-info-raw" |}
+      WHERE "timestamp" >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
+        AND "timestamp" < timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
+        AND dt >= '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prometheusMetricPartitionFormat |}'
+        AND dt <= '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prometheusMetricPartitionFormat |}'
+      GROUP BY namespace, pod, persistentvolumeclaim, date_trunc('hour', "timestamp")
     )
     SELECT
       date_trunc('month', timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart| prestoTimestamp |}') AS report_period_start,
@@ -90,13 +133,16 @@ spec:
       PVCU.interval_start,
       PVCU.interval_start + interval '59' minute + interval '59' second as interval_end,
       PVCU.namespace,
+      PVCI.pod,
       PVCU.persistentvolumeclaim,
       PVCR.persistentvolume,
       PVCR.storageclass,
       PVCC.persistentvolumeclaim_capacity_bytes,
       PVCC.persistentvolumeclaim_capacity_byte_seconds,
       PVCR.volume_request_storage_byte_seconds,
-      PVCU.persistentvolumeclaim_usage_byte_seconds
+      PVCU.persistentvolumeclaim_usage_byte_seconds,
+      PVCL.persistentvolumeclaim_labels,
+      PVL.persistentvolume_labels
     FROM cte_hourly_persistentvolumeclaim_usage AS PVCU
     JOIN cte_hourly_persistentvolumeclaim_requests AS PVCR
         ON PVCU.namespace = PVCR.namespace
@@ -106,9 +152,24 @@ spec:
         ON PVCU.namespace = PVCC.namespace
           AND PVCU.persistentvolumeclaim = PVCC.persistentvolumeclaim
           AND PVCU.interval_start = PVCC.interval_start
+    LEFT JOIN cte_hourly_pvc_labels as PVCL
+        ON PVCU.namespace = PVCL.namespace
+          AND PVCU.persistentvolumeclaim = PVCL.persistentvolumeclaim
+          AND PVCU.interval_start = PVCL.interval_start
+    LEFT JOIN cte_hourly_pv_labels as PVL
+        ON PVCR.namespace = PVL.namespace
+          AND PVCR.persistentvolume = PVL.persistentvolume
+          AND PVCR.interval_start = PVL.interval_start
+    LEFT JOIN cte_pod_pvc_info as PVCI
+        ON PVCU.namespace = PVCI.namespace
+          AND PVCU.persistentvolumeclaim = PVCI.persistentvolumeclaim
+          AND PVCU.interval_start = PVCI.interval_start
   reportQueries:
     - persistentvolumeclaim-capacity-raw
     - persistentvolumeclaim-request-raw
     - persistentvolumeclaim-usage-raw
+    - persistentvolume-labels-raw
+    - persistentvolumeclaim-labels-raw
+    - pod-persistentvolumeclaim-info-raw
   view:
     disabled: true

--- a/roles/setup/files/hccm_openshift_persistentvolumeclaim_scheduled_report.yaml
+++ b/roles/setup/files/hccm_openshift_persistentvolumeclaim_scheduled_report.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: metering.openshift.io/v1alpha1
+kind: Report
+metadata:
+  name: hccm-openshift-persistentvolumeclaim
+spec:
+  generationQuery: "hccm-openshift-persistentvolumeclaim"
+  schedule:
+    period: "hourly"

--- a/roles/setup/files/kube-persistentvolume-labels_report_data_source.yaml
+++ b/roles/setup/files/kube-persistentvolume-labels_report_data_source.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: metering.openshift.io/v1alpha1
+kind: ReportDataSource
+metadata:
+ name: kube-persistentvolume-labels
+spec:
+ promsum:
+  query: "kube-persistentvolume-labels"

--- a/roles/setup/files/kube-persistentvolume_labels_prometheus_query.yaml
+++ b/roles/setup/files/kube-persistentvolume_labels_prometheus_query.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: metering.openshift.io/v1alpha1
+kind: ReportPrometheusQuery
+metadata:
+ name: kube-persistentvolume-labels
+spec:
+ query: |
+   kube_persistentvolume_labels

--- a/roles/setup/files/kube-persistentvolumeclaim-labels_report_data_source.yaml
+++ b/roles/setup/files/kube-persistentvolumeclaim-labels_report_data_source.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: metering.openshift.io/v1alpha1
+kind: ReportDataSource
+metadata:
+ name: kube-persistentvolumeclaim-labels
+spec:
+ promsum:
+  query: "kube-persistentvolumeclaim-labels"

--- a/roles/setup/files/kube-persistentvolumeclaim_labels_prometheus_query.yaml
+++ b/roles/setup/files/kube-persistentvolumeclaim_labels_prometheus_query.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: metering.openshift.io/v1alpha1
+kind: ReportPrometheusQuery
+metadata:
+ name: kube-persistentvolumeclaim-labels
+spec:
+ query: |
+   kube_persistentvolumeclaim_labels

--- a/roles/setup/files/kube-pod-persistentvolumeclaim-info_report_data_source.yaml
+++ b/roles/setup/files/kube-pod-persistentvolumeclaim-info_report_data_source.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: metering.openshift.io/v1alpha1
+kind: ReportDataSource
+metadata:
+ name: kube-pod-persistentvolumeclaim-info
+spec:
+ promsum:
+  query: "kube-pod-persistentvolumeclaim-info"

--- a/roles/setup/files/kube-pod-persistentvolumeclaim_info_prometheus_query.yaml
+++ b/roles/setup/files/kube-pod-persistentvolumeclaim_info_prometheus_query.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: metering.openshift.io/v1alpha1
+kind: ReportPrometheusQuery
+metadata:
+ name: kube-pod-persistentvolumeclaim-info
+spec:
+ query: |
+   kube_pod_spec_volumes_persistentvolumeclaims_info

--- a/roles/setup/files/persistentvolume-labels_report_generation_query.yaml
+++ b/roles/setup/files/persistentvolume-labels_report_generation_query.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: metering.openshift.io/v1alpha1
+kind: ReportGenerationQuery
+metadata:
+  name: "persistentvolume-labels-raw"
+spec:
+  reportDataSources:
+    - "kube-persistentvolume-labels"
+  columns:
+    - name: persistentvolume
+      type: string
+      unit: kubernetes_persistentvolume
+    - name: namespace
+      type: string
+      unit: kubernetes_namespace
+    - name: labels
+      type: map<string, string>
+    - name: timestamp
+      type: timestamp
+      unit: date
+    - name: dt
+      type: string
+  query: |
+    SELECT labels['persistentvolume'] as persistentvolume,
+        labels['namespace'] as namespace,
+        labels,
+        "timestamp",
+        dt
+    FROM {| dataSourceTableName "kube-persistentvolume-labels" |}
+    WHERE element_at(labels, 'persistentvolume') IS NOT NULL

--- a/roles/setup/files/persistentvolumeclaim-labels_report_generation_query.yaml
+++ b/roles/setup/files/persistentvolumeclaim-labels_report_generation_query.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: metering.openshift.io/v1alpha1
+kind: ReportGenerationQuery
+metadata:
+  name: "persistentvolumeclaim-labels-raw"
+spec:
+  reportDataSources:
+    - "kube-persistentvolumeclaim-labels"
+  columns:
+    - name: persistentvolumeclaim
+      type: string
+      unit: kubernetes_persistentvolumeclaim
+    - name: namespace
+      type: string
+      unit: kubernetes_namespace
+    - name: labels
+      type: map<string, string>
+    - name: timestamp
+      type: timestamp
+      unit: date
+    - name: dt
+      type: string
+  query: |
+    SELECT labels['persistentvolumeclaim'] as persistentvolumeclaim,
+        labels['namespace'] as namespace,
+        labels,
+        "timestamp",
+        dt
+    FROM {| dataSourceTableName "kube-persistentvolumeclaim-labels" |}
+    WHERE element_at(labels, 'persistentvolumeclaim') IS NOT NULL

--- a/roles/setup/files/pod-persistentvolumeclaim-info_report_generation_query.yaml
+++ b/roles/setup/files/pod-persistentvolumeclaim-info_report_generation_query.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: metering.openshift.io/v1alpha1
+kind: ReportGenerationQuery
+metadata:
+  name: "pod-persistentvolumeclaim-info-raw"
+spec:
+  reportDataSources:
+    - "kube-pod-persistentvolumeclaim-info"
+  columns:
+    - name: pod
+      type: string
+      unit: kubernetes_pod
+    - name: persistentvolumeclaim
+      type: string
+      unit: kubernetes_persistentvolumeclaim
+    - name: namespace
+      type: string
+      unit: kubernetes_namespace
+    - name: labels
+      type: map<string, string>
+    - name: timestamp
+      type: timestamp
+      unit: date
+    - name: dt
+      type: string
+  query: |
+    SELECT labels['pod'] as pod,
+        labels['persistentvolumeclaim'] as persistentvolumeclaim,
+        labels['namespace'] as namespace,
+        labels,
+        "timestamp",
+        dt
+    FROM {| dataSourceTableName "kube-pod-persistentvolumeclaim-info" |}
+    WHERE element_at(labels, 'persistentvolumeclaim') IS NOT NULL
+        AND element_at(labels, 'pod') IS NOT NULL


### PR DESCRIPTION
## Summary
This is just the YAML definition files for Operator Metering objects to generate OCP storage reports. The format will be similar to our current usage reports. They are separate reports because usage is based around pods, and storage around persistent volume claims, which are tied only to a namespace, not a pod. 

The report will include capacity, requests, usage, and labels. 