### PR TITLE
Remove config and tarball from /tmp when done

### DIFF
--- a/roles/collect/tasks/main.yml
+++ b/roles/collect/tasks/main.yml
@@ -153,3 +153,15 @@
     path: '{{ collect_download_path }}'
     state: absent
   when: collect_delete_after
+
+- name: Remove temp config
+  file:
+    path: '/tmp/{{ collect_ocp_config_file | basename }}'
+    state: absent
+  when: collect_delete_after
+
+- name: Remove tarball
+  file:
+    path: '{{ collect_archive_path }}/{{ collect_archive_filename }}'
+    state: absent
+  when: collect_delete_after


### PR DESCRIPTION
## Summary
This deletes the config.json file and tarball sent to Insights as a cleanup step in the collect role.