### PR TITLE
Ocp4 fixes

### DIFF
--- a/roles/collect/defaults/main.yml
+++ b/roles/collect/defaults/main.yml
@@ -10,7 +10,7 @@ collect_archive_name: korekuta
 collect_delete_after: 'true'
 collect_csv_uuid: '{{ 99999999999999999999 | random | to_uuid }}'
 collect_insights_client_cmd: '/usr/bin/insights-client'
-collect_download_path: '/tmp'
+collect_download_path: '/tmp/korekuta_collect'
 collect_ocp_config_file: '{{ ansible_env.HOME }}/.config/ocp_usage/config.json'
 OCP_CLI: '/usr/bin/oc'
 collect_proxy_server_no_port: 'http://127.0.0.1'

--- a/roles/collect/defaults/main.yml
+++ b/roles/collect/defaults/main.yml
@@ -10,7 +10,7 @@ collect_archive_name: korekuta
 collect_delete_after: 'true'
 collect_csv_uuid: '{{ 99999999999999999999 | random | to_uuid }}'
 collect_insights_client_cmd: '/usr/bin/insights-client'
-collect_download_path: '/tmp/korekuta-collect'
+collect_download_path: '/tmp'
 collect_ocp_config_file: '{{ ansible_env.HOME }}/.config/ocp_usage/config.json'
 OCP_CLI: '/usr/bin/oc'
 collect_proxy_server_no_port: 'http://127.0.0.1'

--- a/roles/collect/defaults/main.yml
+++ b/roles/collect/defaults/main.yml
@@ -10,7 +10,7 @@ collect_archive_name: korekuta
 collect_delete_after: 'true'
 collect_csv_uuid: '{{ 99999999999999999999 | random | to_uuid }}'
 collect_insights_client_cmd: '/usr/bin/insights-client'
-collect_download_path: '/tmp/korekuta_collect'
+collect_download_path: '/tmp/korekuta-collect'
 collect_ocp_config_file: '{{ ansible_env.HOME }}/.config/ocp_usage/config.json'
 OCP_CLI: '/usr/bin/oc'
 collect_proxy_server_no_port: 'http://127.0.0.1'

--- a/roles/collect/molecule/default/prepare.yml
+++ b/roles/collect/molecule/default/prepare.yml
@@ -4,7 +4,7 @@
   gather_facts: true
   vars:
     test_paths:
-      - '/api/v1/namespaces/metering/test/services/https:reporting-operator:http/proxy/api/v1/reports/get'
+      - '/api/v1/reports/get'
   tasks:
     - name: install openshift client
       include_role:
@@ -19,7 +19,7 @@
     - name: create test setup.json
       copy:
         dest: '/tmp/ocp-test-config.json'
-        content: '{"ocp_api":"http://localhost:8001", "ocp_token_file":"/tmp/collect-test-token", "ocp_cluster_id": "test-cluster-id", "ocp_metering_namespace": "metering/test", "ocp_proxy_port": "8001", "ocp_validate_cert": "false"}'
+        content: '{"ocp_api":"http://localhost:8001", "metering_api":"http://localhost:8001", "ocp_token_file":"/tmp/collect-test-token", "ocp_cluster_id": "test-cluster-id", "ocp_metering_namespace": "metering/test", "ocp_proxy_port": "8001", "ocp_validate_cert": "false"}'
         mode: '0644'
 
     - name: create test token file

--- a/roles/collect/molecule/default/tests/test_default.py
+++ b/roles/collect/molecule/default/tests/test_default.py
@@ -10,6 +10,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(  # pylint: disab
 
 download_path = '/tmp/korekuta-collect'  # pylint: disable=invalid-name
 csv_uuid = 'd7449564-67a4-4507-86f2-db70055aa12a'  # pylint: disable=invalid-name
+cluster_id = 'test-cluster-id'
 
 
 def test_download_path(host):
@@ -23,7 +24,7 @@ def test_csv_file(host):
     test_files = ['{}_openshift_usage_report.0.csv'.format(csv_uuid),
                   '{}_openshift_usage_report.1.csv'.format(csv_uuid)]
     for file_name in test_files:
-        csv_file = download_path + '/{}'.format(file_name)
+        csv_file = download_path + '/{}/{}'.format(cluster_id, file_name)
         assert host.file(csv_file).exists
         assert host.file(csv_file).is_file
 
@@ -32,7 +33,7 @@ def test_manifest_file(host):
     """Test manifest file and contents."""
     test_files = ['{}_openshift_usage_report.0.csv'.format(csv_uuid),
                   '{}_openshift_usage_report.1.csv'.format(csv_uuid)]
-    manifest_file = download_path + '/manifest.json'
+    manifest_file = download_path + '/{}'.format(cluster_id) + '/manifest.json'
     assert host.file(manifest_file).exists
     assert host.file(manifest_file).is_file
     manifest = json.loads(host.file(manifest_file).content_string)

--- a/roles/collect/molecule/default/tests/test_default.py
+++ b/roles/collect/molecule/default/tests/test_default.py
@@ -10,7 +10,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(  # pylint: disab
 
 download_path = '/tmp/korekuta-collect'  # pylint: disable=invalid-name
 csv_uuid = 'd7449564-67a4-4507-86f2-db70055aa12a'  # pylint: disable=invalid-name
-cluster_id = 'test-cluster-id'
+cluster_id = 'test-cluster-id'  # pylint: disable=invalid-name
 
 
 def test_download_path(host):

--- a/roles/collect/tasks/main.yml
+++ b/roles/collect/tasks/main.yml
@@ -28,17 +28,6 @@
     files:
       - '{{ ocp_config["ocp_token_file"] }}'
 
-- name: Check for OC command-line
-  stat:
-    path: '{{ OCP_CLI }}'
-  register: check_oc
-
-- name: OCP_CLI does not exits
-  fail:
-    msg: 'No file was found for OCP_CLI at "{{ OCP_CLI }}".'
-  when:
-    - not check_oc.stat.exists
-
 - name: Set facts from OCP config
   set_fact:
     ocp_validate_cert: '{{ ocp_config["ocp_validate_cert"] }}'
@@ -48,17 +37,17 @@
   set_fact:
     ocp_insecure_login: '--insecure-skip-tls-verify={{ ocp_validate_cert }}'
     api_host: '{{ ocp_config["ocp_api"] }}'
-    api_path: 'api/v1/namespaces/{{ ocp_metering_namespace }}'
+    api_path: '{{ ocp_config["ocp_api_route"] }}'
     current_csv_uuid: '{{ collect_csv_uuid }}'  # bug workaround
     format: "&format={{ collect_format }}"
     namespace: "&namespace={{ ocp_metering_namespace }}"
+    temp_config_path: '/tmp/{{ ocp_config["ocp_cluster_id"] }}_{{ collect_ocp_config_file | basename }}'
 
-# conditional - with_proxy
-- name: Define facts from OCP config with proxy
-  set_fact:
-    api_host: '{{ collect_proxy_server_no_port }}:{{ ocp_config["ocp_proxy_port"] }}'
-    api_path: '{{ api_path }}/services/https:reporting-operator:http/proxy/api/v1/reports/get'
-  tags: with_proxy
+# When multiple users use the same machine, we can run into file ownership issues here
+# if something goes wrong and the file is not cleaned up
+- name: Move config file to cluster-specific config name
+  command: 'mv /tmp/{{ collect_ocp_config_file | basename }} {{ temp_config_path }}'
+
 
 # getting a little clever to build lists to append into
 - name: initialize fact lists
@@ -79,9 +68,14 @@
     api_urls: "{{ api_urls + [api_host+'/'+api_path+item] }}"
   with_items: "{{ api_params }}"
 
+# Use a cluster specific path
+- name: Set download_path
+  set_fact:
+    temp_download_path: "{{ collect_download_path }}/{{ ocp_config['ocp_cluster_id'] }}/korekuta_collect"
+
 - name: Create temp dir for downloaded files
   file:
-    path: '{{ collect_download_path }}'
+    path: '{{ temp_download_path }}'
     state: directory
 
 - name: Read the OCP token
@@ -90,22 +84,11 @@
   changed_when: false
   no_log: true
 
-- name: Log in to OCP cluster
-  command: '{{ OCP_CLI }} login {{ ocp_config["ocp_api"] }} {{ ocp_insecure_login }} --token {{ cat_token.stdout }}'
-  when: cat_token.stdout is defined and cat_token
-  no_log: true
-
-- name: Run OC Proxy
-  command: 'nohup {{ OCP_CLI }} proxy --port={{ ocp_config["ocp_proxy_port"] }} </dev/null >/dev/null 2>&1 &'
-  async: 120
-  poll: 0
-  when: cat_token.stdout is defined and cat_token
-  tags: with_proxy
-
 - name: Download OCP report from endpoint
   get_url:
     url: '{{ item }}'
-    dest: '{{ collect_download_path }}/{{ current_csv_uuid }}_openshift_usage_report.{{ idx }}.{{ collect_format }}'
+    headers: "Authorization:Bearer {{ cat_token.stdout }}"
+    dest: '{{ temp_download_path }}/{{ current_csv_uuid }}_openshift_usage_report.{{ idx }}.{{ collect_format }}'
     validate_certs: '{{ ocp_config["ocp_validate_cert"] | bool }}'
   with_items: "{{ api_urls }}"
   loop_control:
@@ -124,13 +107,13 @@
 - name: Generate archive manifest
   template:
     src: 'templates/manifest.j2'
-    dest: '{{ collect_download_path }}/manifest.json'
+    dest: '{{ temp_download_path }}/manifest.json'
 
 - name: Create tarball
   archive:
     format: '{{ collect_archive_format }}'
     dest: '{{ collect_archive_path }}/{{ collect_archive_filename }}'
-    path: "{{ collect_download_path }}"
+    path: "{{ temp_download_path }}"
     remove: '{{ collect_delete_after }}'
   register: archive_result
 
@@ -154,13 +137,13 @@
 
 - name: Remove temp files
   file:
-    path: '{{ collect_download_path }}'
+    path: '{{ temp_download_path }}'
     state: absent
   when: collect_delete_after
 
 - name: Remove temp config
   file:
-    path: '/tmp/{{ collect_ocp_config_file | basename }}'
+    path: '{{ temp_config_path }}'
     state: absent
   when: collect_delete_after
 

--- a/roles/collect/tasks/main.yml
+++ b/roles/collect/tasks/main.yml
@@ -37,7 +37,7 @@
   set_fact:
     ocp_insecure_login: '--insecure-skip-tls-verify={{ ocp_validate_cert }}'
     api_host: '{{ ocp_config["ocp_api"] }}'
-    api_path: '{{ ocp_config["ocp_api_route"] }}'
+    api_path: '{{ ocp_config["metering_api"] }}/api/v1/reports/get'
     current_csv_uuid: '{{ collect_csv_uuid }}'  # bug workaround
     format: "&format={{ collect_format }}"
     namespace: "&namespace={{ ocp_metering_namespace }}"
@@ -65,7 +65,7 @@
 # this appends the string inside the brackets to the 'api_urls' list.
 - name: assemble compiled URL facts, append to list.
   set_fact:
-    api_urls: "{{ api_urls + [api_host+'/'+api_path+item] }}"
+    api_urls: "{{ api_urls + [api_path+item] }}"
   with_items: "{{ api_params }}"
 
 # Use a cluster specific path

--- a/roles/collect/tasks/main.yml
+++ b/roles/collect/tasks/main.yml
@@ -41,13 +41,13 @@
     current_csv_uuid: '{{ collect_csv_uuid }}'  # bug workaround
     format: "&format={{ collect_format }}"
     namespace: "&namespace={{ ocp_metering_namespace }}"
-    temp_config_path: '/tmp/{{ ocp_config["ocp_cluster_id"] }}_{{ collect_ocp_config_file | basename }}'
+    collect_config_path: '/tmp/{{ ocp_config["ocp_cluster_id"] }}_{{ collect_ocp_config_file | basename }}'
 
 # When multiple users use the same machine, we can run into file ownership issues here
 # if something goes wrong and the file is not cleaned up
 - name: Move config file to cluster-specific config name
-  command: 'mv /tmp/{{ collect_ocp_config_file | basename }} {{ temp_config_path }}'
-  when: temp_config_path is defined
+  command: 'mv /tmp/{{ collect_ocp_config_file | basename }} {{ collect_config_path }}'
+  when: collect_config_path is defined
 
 
 # getting a little clever to build lists to append into
@@ -145,7 +145,7 @@
 
 - name: Remove temp config
   file:
-    path: '{{ temp_config_path }}'
+    path: '{{ collect_config_path }}'
     state: absent
   when: collect_delete_after
 

--- a/roles/collect/tasks/main.yml
+++ b/roles/collect/tasks/main.yml
@@ -47,6 +47,7 @@
 # if something goes wrong and the file is not cleaned up
 - name: Move config file to cluster-specific config name
   command: 'mv /tmp/{{ collect_ocp_config_file | basename }} {{ temp_config_path }}'
+  when: temp_config_path is defined
 
 
 # getting a little clever to build lists to append into
@@ -71,12 +72,13 @@
 # Use a cluster specific path
 - name: Set download_path
   set_fact:
-    temp_download_path: "{{ collect_download_path }}/{{ ocp_config['ocp_cluster_id'] }}/korekuta_collect"
+    collect_cluster_download_path: '{{ collect_download_path }}/{{ ocp_config["ocp_cluster_id"] }}'
 
 - name: Create temp dir for downloaded files
   file:
-    path: '{{ temp_download_path }}'
+    path: '{{ collect_cluster_download_path }}'
     state: directory
+    mode: 0777
 
 - name: Read the OCP token
   command: 'cat {{ ocp_config["ocp_token_file"] }}'
@@ -88,7 +90,7 @@
   get_url:
     url: '{{ item }}'
     headers: "Authorization:Bearer {{ cat_token.stdout }}"
-    dest: '{{ temp_download_path }}/{{ current_csv_uuid }}_openshift_usage_report.{{ idx }}.{{ collect_format }}'
+    dest: '{{ collect_cluster_download_path }}/{{ current_csv_uuid }}_openshift_usage_report.{{ idx }}.{{ collect_format }}'
     validate_certs: '{{ ocp_config["ocp_validate_cert"] | bool }}'
   with_items: "{{ api_urls }}"
   loop_control:
@@ -107,13 +109,13 @@
 - name: Generate archive manifest
   template:
     src: 'templates/manifest.j2'
-    dest: '{{ temp_download_path }}/manifest.json'
+    dest: '{{ collect_cluster_download_path }}/manifest.json'
 
 - name: Create tarball
   archive:
     format: '{{ collect_archive_format }}'
     dest: '{{ collect_archive_path }}/{{ collect_archive_filename }}'
-    path: "{{ temp_download_path }}"
+    path: "{{ collect_cluster_download_path }}"
     remove: '{{ collect_delete_after }}'
   register: archive_result
 
@@ -137,7 +139,7 @@
 
 - name: Remove temp files
   file:
-    path: '{{ temp_download_path }}'
+    path: '{{ collect_cluster_download_path }}'
     state: absent
   when: collect_delete_after
 

--- a/roles/setup/molecule/default/playbook.yml
+++ b/roles/setup/molecule/default/playbook.yml
@@ -7,6 +7,7 @@
     OCP_TOKEN_PATH: "{{ ansible_env.HOME }}/ocp_token"
     OCP_METERING_NAMESPACE: metering
     OCP_CLI: /usr/local/bin/oc
+    METERING_API: http://127.0.0.1
     setup_reports: false
 
   roles:

--- a/roles/setup/molecule/default/tests/test_default.py
+++ b/roles/setup/molecule/default/tests/test_default.py
@@ -29,3 +29,4 @@ def test_manifest_file(host):
     assert host.file(config_file).contains('"ocp_metering_namespace":')
     assert host.file(config_file).contains('"ocp_proxy_port":')
     assert host.file(config_file).contains('"ocp_validate_cert":')
+    assert host.file(config_file).contains('"metering_api":')

--- a/roles/setup/tasks/main.yml
+++ b/roles/setup/tasks/main.yml
@@ -16,6 +16,7 @@
     - OCP_API
     - OCP_TOKEN_PATH
     - OCP_METERING_NAMESPACE
+    - METERING_API
 
 - name: Check that OCP_TOKEN_PATH exists
   stat:
@@ -214,6 +215,7 @@
     - config_content.get('ocp_token_file') != OCP_TOKEN_PATH
     - config_content.get('ocp_cluster_id') != ocp_cluster_id
     - config_content.get('ocp_metering_namespace') != OCP_METERING_NAMESPACE
+    - config_content.get('metering_api') != METERING_API
 
 - name: Display New Cluster Identifier
   debug:

--- a/roles/setup/tasks/main.yml
+++ b/roles/setup/tasks/main.yml
@@ -137,7 +137,7 @@
       changed_when: false
 
     - name: Check for hccm-usage-report Report
-      command: '{{ OCP_CLI }} get Report {{ setup_report_name }}'
+      command: '{{ OCP_CLI }} get Report {{ setup_usage_report_name }}'
       register: oc_get_report
       changed_when: false
       ignore_errors: true
@@ -145,7 +145,7 @@
         - oc_project.stdout is defined and oc_project
 
     - name: Check for hccm-usage-report ReportQuery
-      command: '{{ OCP_CLI }} get ReportQuery {{ setup_report_name }}'
+      command: '{{ OCP_CLI }} get ReportQuery {{ setup_usage_report_name }}'
       register: oc_get_report_generation_query
       changed_when: false
       ignore_errors: true
@@ -171,7 +171,7 @@
     - name: Copy hccm-usage-report files
       copy:
         src: '{{ item }}'
-        dest: '{{ ocp_temp_file_dir }}'
+        dest: '{{ ocp_temp_file_dir.path }}'
       with_fileglob:
         - 'files/kube*'
         - 'files/pod*'
@@ -185,7 +185,7 @@
         - oc_get_storage_report_generation_query.rc is defined and  oc_get_storage_report_generation_query.rc != 0
 
     - name: Create Operator Metering definitions
-      command: '{{ OCP_CLI }} create -f {{ ocp_temp_file_dir }}'
+      command: '{{ OCP_CLI }} create -f {{ ocp_temp_file_dir.path }}'
       when:
         - oc_project.stdout is defined and oc_project
         - oc_get_report.rc is defined and  oc_get_report.rc != 0

--- a/roles/setup/templates/config.j2
+++ b/roles/setup/templates/config.j2
@@ -4,5 +4,6 @@
     "ocp_cluster_id": "{{ ocp_cluster_id }}",
     "ocp_metering_namespace": "{{ OCP_METERING_NAMESPACE }}",
     "ocp_proxy_port": "{{ ocp_proxy_port }}",
-    "ocp_validate_cert": "{{ ocp_validate_cert }}"
+    "ocp_validate_cert": "{{ ocp_validate_cert }}",
+    "metering_api": "{{ METERING_API }}"
 }


### PR DESCRIPTION
## Summary 
These changes allow korekuta setup and collect to run successfully against an OpenShift 3.11 and 4.x cluster with the most recent operator metering changes. Some small bugfixes, modifications to add cluster_id to the files in the /tmp/ directory to avoid permissions issues when multiple users on the same machine use korekuta (like we have), and a change to use a route to access the operator metering report API. 

## Testing
Setup an OpenShift 4 cluster and our OpenShift 3.11 on RHEV successfully. 