### PR TITLE
Cluster unique config file

### DIFF
--- a/roles/collect/tasks/main.yml
+++ b/roles/collect/tasks/main.yml
@@ -60,12 +60,6 @@
     collect_config_path: '/tmp/{{ OCP_CLUSTER_ID }}_{{ collect_ocp_config_file | basename }}'
     OCP_CLI: ocp_config["ocp_cli"]
 
-# When multiple users use the same machine, we can run into file ownership issues here
-# if something goes wrong and the file is not cleaned up
-- name: Move config file to cluster-specific config name
-  command: 'mv -f /tmp/{{ collect_ocp_config_file | basename }} {{ collect_config_path }}'
-  when: collect_config_path is defined
-
 # getting a little clever to build lists to append into
 - name: initialize fact lists
   set_fact:

--- a/roles/collect/tasks/main.yml
+++ b/roles/collect/tasks/main.yml
@@ -10,6 +10,10 @@
   set_fact:
     collect_ocp_config_file: '{{ collect_ocp_config_file_cluster_root }}/{{ OCP_CLUSTER_ID }}/{{ collect_ocp_config_filename }}'
 
+- name: Define Cluster-unique config file name
+  set_fact:
+    collect_ocp_cluster_config_file: '/tmp/{{ OCP_CLUSTER_ID }}_{{ collect_ocp_config_file }}'
+
 # looping over blocks isn't available, so we'll loop over included tasks instead.
 # see: https://github.com/ansible/ansible/issues/13262#issuecomment-335904803
 - name: validate dependencies
@@ -24,13 +28,13 @@
 - name: Fetch OCP config file from remote host
   fetch:
     src: '{{ collect_ocp_config_file }}'
-    dest: '/tmp/'
+    dest: '{{ collect_ocp_cluster_config_file }}'
     fail_on_missing: true
     flat: true
 
 - name: Read in OCP configuration file
   include_vars:
-    file: '/tmp/{{ collect_ocp_config_file | basename }}'
+    file: '{{ collect_ocp_cluster_config_file }}'
     name: ocp_config
 
 - name: validate ocp_config_file dependencies


### PR DESCRIPTION
## Summary
This should resolve a race condition where multiple cron jobs for multiple clusters run at the same time. Whichever job had most recently written to `/tmp/config.json` seemed to control credentials and which cluster was being run. This was causing 1 cluster's data to come in for 2 providers in cost management. 