### PR TITLE
DONT MERGE - Example role for performing file split.

### DIFF
--- a/roles/collect/tasks/main.yml
+++ b/roles/collect/tasks/main.yml
@@ -1,4 +1,19 @@
 ---
+- set_fact:
+    csv_file_list: [/tmp/69a5ae95-f66f-4149-874c-67041629a538_openshift_usage_report.0.csv, /tmp/69a5ae95-f66f-4149-874c-67041629a538_openshift_usage_report.1.csv]
+    OCP_CLUSTER_ID: "69a5ae95-f66f-4149-874c-67041629a538"
+    collect_cluster_download_path: "/tmp"
+
+- name: Split payload in loop
+  include_role:
+    name: 'split-payload'
+  vars:
+    file: '{{ item }}'
+    OCP_CLUSTER_ID: '{{ OCP_CLUSTER_ID }}'
+    download_path: '{{ collect_cluster_download_path }}'
+  with_items:
+    - '{{ csv_file_list }}'
+
 - name: Ensure needed variables are set
   fail:
     msg: 'You must supply "-e {{ item }}=<{{ item }}>".'
@@ -133,55 +148,12 @@
   with_items:
     - '{{ csv_stat_result.results }}'
 
-- name: CSV filename to json
-  set_fact:
-    csv_files_json: "{{ csv_files | to_json }}"
-
-- name: Generate archive manifest
-  template:
-    src: 'templates/manifest.j2'
-    dest: '{{ collect_cluster_download_path }}/manifest.json'
-
-- name: Create tarball
-  archive:
-    format: '{{ collect_archive_format }}'
-    dest: '{{ collect_archive_path }}/{{ collect_archive_filename }}'
-    path: "{{ collect_cluster_download_path }}"
-    remove: '{{ collect_delete_after }}'
-  register: archive_result
-
-- name: Set Insights Client GPG Flag
-  set_fact:
-    collect_insights_bypass_gpg_flag: '--no-gpg'
-  when:
-    - collect_insights_bypass_gpg == 'True'
-
-- name: Send payload to the Insights Client
-  command: >-
-    {{ collect_insights_client_cmd }} {{ collect_insights_bypass_gpg_flag }}
-    --payload={{ collect_archive_path }}/{{ collect_archive_filename }}
-    --content-type={{ collect_content_type }}
-
-  environment:
-    BYPASS_GPG: '{{ collect_insights_bypass_gpg }}'
-    EGG: '{{ collect_insights_egg_path }}'
-  become: true
-  when: archive_result.state == 'file'
-
-- name: Remove temp files
-  file:
-    path: '{{ collect_cluster_download_path }}'
-    state: absent
-  when: collect_delete_after
-
-- name: Remove temp config
-  file:
-    path: '{{ collect_config_path }}'
-    state: absent
-  when: collect_delete_after
-
-- name: Remove tarball
-  file:
-    path: '{{ collect_archive_path }}/{{ collect_archive_filename }}'
-    state: absent
-  when: collect_delete_after
+- name: Split payload in loop
+  include_role:
+    name: 'split-payload'
+  vars:
+    file: '{{ item }}'
+    ocp_config: '{{ ocp_config }}'
+    download_path: '{{ collect_cluster_download_path }}'
+  with_items:
+    - '{{ csv_stat_result.results }}'

--- a/roles/split-payload/.travis.yml
+++ b/roles/split-payload/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "2.7"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/roles/split-payload/.yamllint
+++ b/roles/split-payload/.yamllint
@@ -1,0 +1,33 @@
+---
+# Based on ansible-lint config
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
+  truthy: disable

--- a/roles/split-payload/README.md
+++ b/roles/split-payload/README.md
@@ -1,0 +1,38 @@
+Role Name
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/roles/split-payload/defaults/main.yml
+++ b/roles/split-payload/defaults/main.yml
@@ -1,0 +1,15 @@
+---
+# defaults file for split-payload
+
+
+split_manifest_uuid: '{{ 99999999999999999999 | random | to_uuid }}'
+split_download_path: '/tmp/korekuta-collect'
+split_archive_format: gz
+split_archive_path: '/tmp'
+split_archive_name: korekuta
+split_delete_after: 'true'
+split_content_type: 'application/vnd.redhat.hccm.tar+tgz'
+split_insights_bypass_gpg: 'False'
+split_insights_egg_path: '/etc/insights-client/rpm.egg'
+split_insights_bypass_gpg_flag: ''
+split_max_size: 10000

--- a/roles/split-payload/handlers/main.yml
+++ b/roles/split-payload/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for split-payload

--- a/roles/split-payload/meta/main.yml
+++ b/roles/split-payload/meta/main.yml
@@ -1,0 +1,53 @@
+galaxy_info:
+  author: your name
+  description: your role description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.9
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.
+  

--- a/roles/split-payload/molecule/default/INSTALL.rst
+++ b/roles/split-payload/molecule/default/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ pip install 'molecule[docker]'

--- a/roles/split-payload/molecule/default/converge.yml
+++ b/roles/split-payload/molecule/default/converge.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: "Include split-payload"
+      include_role:
+        name: "split-payload"

--- a/roles/split-payload/molecule/default/molecule.yml
+++ b/roles/split-payload/molecule/default/molecule.yml
@@ -1,0 +1,13 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: instance
+    image: docker.io/pycontribs/centos:7
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/roles/split-payload/molecule/default/verify.yml
+++ b/roles/split-payload/molecule/default/verify.yml
@@ -1,0 +1,9 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  tasks:
+  - name: Example assertion
+    assert:
+      that: true

--- a/roles/split-payload/tasks/main.yml
+++ b/roles/split-payload/tasks/main.yml
@@ -1,0 +1,153 @@
+---
+# tasks file for split-payload
+
+- name: File to split
+  debug:
+    var: file
+    verbosity: 2
+
+- stat:
+    path: "{{ file }}"
+  register: file_stat
+
+- name: Check file needs splitting
+  set_fact:
+    split_file: "{{ ((split_max_size | int) < file_stat.stat.size) | bool }}"
+
+- name: Get csv contents
+  set_fact:
+    file_contents: "{{ lookup('file', file).splitlines() }}"
+  no_log: true
+  when:
+    - split_file
+
+- name: Get csv header and total line count
+  set_fact:
+    csv_download_path: "{{ download_path }}"
+    csv_basename: "{{ file | basename }}"
+    csv_header: "{{ file_contents[0] }}"
+    total_lines: "{{ file_contents | length }}"
+    half_lines: "{{ (file_contents | length / 2) | int }}"
+    half_lines_plus_one: "{{ (file_contents | length / 2) | int + 1}}"
+  when:
+    - split_file
+
+- name: Get csv split contents
+  set_fact:
+    csv_name_no_ext: "{{ csv_basename[:-3] }}"
+    first_half: "{{ file_contents[:half_lines | int] }}"
+    second_half: "{{ file_contents[half_lines_plus_one | int:] }}"
+  no_log: true
+  when:
+    - split_file
+
+- name: Prepend header to second_half
+  set_fact:
+    second_half: "{{ [csv_header] + second_half }}"
+  no_log: true
+  when:
+    - split_file
+
+- name: Create contents with newlines
+  set_fact:
+    first_half_newlines: "{{ first_half | join('\n') }}"
+    second_half_newlines: "{{ second_half | join('\n') }}"
+    first_half_file_path: "{{ download_path + csv_name_no_ext + '0.csv' }}"
+    second_half_file_path: "{{ download_path + csv_name_no_ext + '1.csv' }}"
+  when:
+    - split_file
+
+- name: Create new file paths
+  set_fact:
+    first_half_file_path: "{{ download_path + '/' + csv_name_no_ext + '0.csv' }}"
+    second_half_file_path: "{{ download_path + '/' + csv_name_no_ext + '1.csv' }}"
+  when:
+    - split_file
+
+- name: Copy first_half contents
+  copy:
+    content: "{{ first_half_newlines }}"
+    dest: "{{ first_half_file_path }}"
+  when:
+    - split_file
+
+- name: Copy second_half contents
+  copy:
+    content: "{{ second_half_newlines }}"
+    dest: "{{ second_half_file_path }}"
+  when:
+    - split_file
+
+- name: Create new csv_file_list
+  set_fact:
+    csv_file_list: "{{ [first_half_file_path] + [second_half_file_path] }}"
+  when:
+    - split_file
+
+- name: Split payload in loop
+  include_role:
+    name: 'split-payload'
+  vars:
+    file: '{{ item }}'
+    ocp_config: '{{ ocp_config }}'
+    download_path: '{{ csv_download_path }}'
+  with_items:
+    - '{{ csv_file_list }}'
+  when:
+    - split_file
+
+- name: append filename to fact list
+  set_fact:
+    csv_files: "{{ csv_files + [item | basename] }}"
+  with_items: "{{ csv_file_list }}"
+
+- name: CSV filename to json
+  set_fact:
+    csv_files_json: "{{ csv_files | to_json }}"
+  when:
+    - not split_file
+
+- name: Generate archive manifest
+  template:
+    src: 'templates/manifest.j2'
+    dest: '{{ csv_download_path }}/manifest.json'
+  when:
+    - not split_file
+
+- name: Create tarball
+  archive:
+    format: '{{ split_archive_format }}'
+    dest: '{{ split_archive_path }}/{{ split_archive_filename }}'
+    path: "{{ csv_download_path }}"
+    remove: '{{ split_delete_after }}'
+  register: archive_result
+  when:
+    - not split_file
+
+- name: Set Insights Client GPG Flag
+  set_fact:
+    split_insights_bypass_gpg_flag: '--no-gpg'
+  when:
+    - split_insights_bypass_gpg == 'True'
+    - not split_file
+
+- name: Send payload to the Insights Client
+  command: >-
+    {{ split_insights_client_cmd }} {{ split_insights_bypass_gpg_flag }}
+    --payload={{ split_archive_path }}/{{ split_archive_filename }}
+    --content-type={{ split_content_type }}
+  environment:
+    BYPASS_GPG: '{{ split_insights_bypass_gpg }}'
+    EGG: '{{ split_insights_egg_path }}'
+  become: true
+  when: 
+    - archive_result.state == 'file'
+    - not split_file
+
+- name: Remove tarball
+  file:
+    path: '{{ split_archive_path }}/{{ split_archive_filename }}'
+    state: absent
+  when: 
+    - split_delete_after
+    - not split_file

--- a/roles/split-payload/templates/manifest.j2
+++ b/roles/split-payload/templates/manifest.j2
@@ -1,0 +1,6 @@
+{
+    "files": {{ csv_files_json }},
+    "date": "{{ ansible_date_time.iso8601 }}",
+    "uuid": "{{ split_manifest_uuid }}",
+    "cluster_id": "{{ OCP_CLUSTER_ID }}"
+}

--- a/roles/split-payload/tests/inventory
+++ b/roles/split-payload/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/split-payload/tests/test.yml
+++ b/roles/split-payload/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - split-payload

--- a/roles/split-payload/vars/main.yml
+++ b/roles/split-payload/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for split-payload


### PR DESCRIPTION
This is an example of how we could do the file splitting:
`ansible-playbook ./ocp_usage_playbook.yml -vv --tags=collect`

This is just a rough example that needs more clean up, but wanted to put the gist out there.

You will note that this short circuits most of the collect logic to show what would be done after the files are downloaded, but I wanted to make it something simple to run.

I placed two sample csv files from previous output int `/tmp` and referenced them in the list of csv files.

[69a5ae95-f66f-4149-874c-67041629a538_openshift_usage_report.0.txt](https://github.com/project-koku/korekuta/files/4277678/69a5ae95-f66f-4149-874c-67041629a538_openshift_usage_report.0.txt)
[69a5ae95-f66f-4149-874c-67041629a538_openshift_usage_report.1.txt](https://github.com/project-koku/korekuta/files/4277682/69a5ae95-f66f-4149-874c-67041629a538_openshift_usage_report.1.txt)

You will need to swap the extension back to `.csv`

Let me know what you think.